### PR TITLE
IStreamReader/IStreamWriter: Simplify buffer functions where applicable

### DIFF
--- a/include/athena/IStreamReader.hpp
+++ b/include/athena/IStreamReader.hpp
@@ -103,10 +103,9 @@ public:
    * @return The buffer at the current position from the given length.
    */
   std::unique_ptr<atInt8[]> readBytes(atUint64 length) {
-    atInt8* buf = new atInt8[length];
-    memset(buf, 0, length);
-    readUBytesToBuf(buf, length);
-    return std::unique_ptr<atInt8[]>(buf);
+    auto buf = std::make_unique<atInt8[]>(length);
+    readUBytesToBuf(buf.get(), length);
+    return buf;
   }
 
   /** @brief Reads a byte at the current position and advances the current position.
@@ -114,10 +113,9 @@ public:
    *  @return The buffer at the current position from the given length.
    */
   std::unique_ptr<atUint8[]> readUBytes(atUint64 length) {
-    atUint8* buf = new atUint8[length];
-    memset(buf, 0, length);
-    readUBytesToBuf(buf, length);
-    return std::unique_ptr<atUint8[]>(buf);
+    auto buf = std::make_unique<atUint8[]>(length);
+    readUBytesToBuf(buf.get(), length);
+    return buf;
   }
 
   /** @brief Attempts to read a fixed length of data into a pre-allocated buffer.

--- a/include/athena/IStreamWriter.hpp
+++ b/include/athena/IStreamWriter.hpp
@@ -977,9 +977,8 @@ public:
     if (length == 0)
       return;
 
-    std::unique_ptr<atUint8[]> tmp(new atUint8[length]);
-    memset(tmp.get(), val, length);
-    writeUBytes(tmp.get(), length);
+    const std::vector<atUint8> tmp(length, val);
+    writeUBytes(tmp.data(), length);
   }
 
   void fill(atInt8 val, atUint64 length) { fill((atUint8)val, length); }


### PR DESCRIPTION
We can simply use std::make_unique instead of raw new + memset. For fill(), we can just use std::vector, given one of its constructors allows for an initial value to be specified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/libathena/athena/44)
<!-- Reviewable:end -->
