### PR TITLE
Global: Change <iostream> include into <ostream>

### DIFF
--- a/include/athena/Global.hpp
+++ b/include/athena/Global.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <iostream>
+#include <ostream>
 #include "athena/Types.hpp"
 
 #define FMT_STRING_ALIAS 1

--- a/src/athena/Global.cpp
+++ b/src/athena/Global.cpp
@@ -2,6 +2,7 @@
 #include "athena/Utility.hpp"
 #include <cstdio>
 #include <cstdlib>
+#include <iostream>
 
 #define FMT_STRING_ALIAS 1
 #define FMT_ENFORCE_COMPILE_STRING 1


### PR DESCRIPTION
`<iostream>` injects a static constructor into every translation unit that includes the header⁠—even if [nothing](https://godbolt.org/z/bXCJMf) from the header is used. This can result in minor initial program slowdown, as all of these constructors need to run before main() can execute.

Instead, we can use `<ostream>`, which includes all of the necessary machinery that we need, placing the `<iostream>` instance into the cpp file, preventing it from propagating across translation units.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/libathena/athena/47)
<!-- Reviewable:end -->
