### PR TITLE
General: Include headers that are necessary

### DIFF
--- a/include/LZ77/LZType10.hpp
+++ b/include/LZ77/LZType10.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "LZBase.hpp"
+#include "LZ77/LZBase.hpp"
 
 class LZType10 : public LZBase {
 public:

--- a/include/LZ77/LZType11.hpp
+++ b/include/LZ77/LZType11.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "LZBase.hpp"
+#include "LZ77/LZBase.hpp"
 
 class LZType11 : public LZBase {
 public:

--- a/include/athena/Checksums.hpp
+++ b/include/athena/Checksums.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "athena/Global.hpp"
+#include "athena/Types.hpp"
 
 namespace athena::checksums {
 atUint64 crc64(const atUint8* data, atUint64 length, atUint64 seed = 0xFFFFFFFFFFFFFFFF,

--- a/include/athena/Compression.hpp
+++ b/include/athena/Compression.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "athena/Global.hpp"
+#include "athena/Types.hpp"
 
 namespace athena::io::Compression {
 // Zlib compression

--- a/include/athena/DNA.hpp
+++ b/include/athena/DNA.hpp
@@ -6,12 +6,16 @@
  * Any changes to the types or namespacing must be reflected in 'atdna/main.cpp'
  */
 
-#include "Global.hpp"
-#include "IStreamReader.hpp"
-#include "IStreamWriter.hpp"
-#include "DNAOp.hpp"
-#include <vector>
 #include <memory>
+#include <string>
+#include <vector>
+
+#include <sys/types.h>
+
+#include "athena/DNAOp.hpp"
+#include "athena/Global.hpp"
+#include "athena/IStreamReader.hpp"
+#include "athena/IStreamWriter.hpp"
 
 namespace athena::io {
 

--- a/include/athena/DNAOp.hpp
+++ b/include/athena/DNAOp.hpp
@@ -1,11 +1,16 @@
 #pragma once
 
-#include "IStreamReader.hpp"
-#include "IStreamWriter.hpp"
-#include "YAMLDocReader.hpp"
-#include "YAMLDocWriter.hpp"
-#include "ChecksumsLiterals.hpp"
+#include <cstddef>
+#include <cstdint>
+#include <string>
 #include <type_traits>
+#include <vector>
+
+#include "athena/ChecksumsLiterals.hpp"
+#include "athena/IStreamReader.hpp"
+#include "athena/IStreamWriter.hpp"
+#include "athena/YAMLDocReader.hpp"
+#include "athena/YAMLDocWriter.hpp"
 
 namespace athena::io {
 

--- a/include/athena/DNAYaml.hpp
+++ b/include/athena/DNAYaml.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
-#include "YAMLDocReader.hpp"
-#include "YAMLDocWriter.hpp"
-#include "DNA.hpp"
-#include "FileReader.hpp"
-#include "FileWriter.hpp"
+#include <string>
+#include <type_traits>
+
+#include "athena/DNA.hpp"
+#include "athena/FileReader.hpp"
+#include "athena/FileWriter.hpp"
+#include "athena/YAMLDocReader.hpp"
+#include "athena/YAMLDocWriter.hpp"
 
 namespace athena::io {
 

--- a/include/athena/Dir.hpp
+++ b/include/athena/Dir.hpp
@@ -1,11 +1,9 @@
 #pragma once
 
-#include "athena/FileInfo.hpp"
-#include <cstdio>
-#include <vector>
+#include <string>
 
 #if _WIN32
-typedef int mode_t;
+using mode_t = int;
 #endif
 
 namespace athena {
@@ -18,8 +16,6 @@ public:
 
   bool isDir() const;
   static bool isDir(std::string_view dir) { return Dir(dir).isDir(); }
-
-  std::vector<FileInfo> files() const;
 
   bool cd(std::string_view path);
   bool rm(std::string_view path);

--- a/include/athena/FileInfo.hpp
+++ b/include/athena/FileInfo.hpp
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "athena/Global.hpp"
+#include "athena/Types.hpp"
 
 namespace athena {
 class FileInfo {

--- a/include/athena/FileReader.hpp
+++ b/include/athena/FileReader.hpp
@@ -9,9 +9,11 @@
 #include <cstdio>
 #endif
 
-#include <string>
 #include <memory>
+#include <string>
+
 #include "athena/IStreamReader.hpp"
+#include "athena/Types.hpp"
 
 namespace athena::io {
 class FileReader : public IStreamReader {

--- a/include/athena/FileWriter.hpp
+++ b/include/athena/FileWriter.hpp
@@ -8,7 +8,9 @@
 #else
 #include <cstdio>
 #endif
+
 #include "athena/IStreamWriter.hpp"
+#include "athena/Types.hpp"
 
 namespace athena::io {
 class FileWriter : public IStreamWriter {

--- a/include/athena/IStream.hpp
+++ b/include/athena/IStream.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Global.hpp"
+#include "athena/Global.hpp"
 
 namespace athena::io {
 std::ostream& operator<<(std::ostream& os, Endian& endian);

--- a/include/athena/IStreamReader.hpp
+++ b/include/athena/IStreamReader.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
-#include <memory>
 #include <functional>
-#include "utf8proc.h"
-#include "Utility.hpp"
-#include "IStream.hpp"
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+#include "athena/IStream.hpp"
+#include "athena/Utility.hpp"
 
 namespace athena::io {
 /** @brief The IStreamReader class defines a basic API for reading from streams, Implementors are provided with one pure

--- a/include/athena/IStreamWriter.hpp
+++ b/include/athena/IStreamWriter.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
-#include "utf8proc.h"
-#include "IStream.hpp"
-#include "Utility.hpp"
-#include <memory>
+#include <string>
+#include <type_traits>
 #include <vector>
+
+#include "utf8proc.h"
+
+#include "athena/IStream.hpp"
+#include "athena/Utility.hpp"
 
 namespace athena::io {
 class IStreamWriter : public IStream {

--- a/include/athena/MemoryWriter.hpp
+++ b/include/athena/MemoryWriter.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <string>
 #include <memory>
-#include <functional>
+#include <string>
+
 #include "athena/IStreamWriter.hpp"
 
 namespace athena::io {

--- a/include/athena/Socket.hpp
+++ b/include/athena/Socket.hpp
@@ -1,15 +1,12 @@
 #pragma once
 
-#include <sys/types.h>
-#include <fcntl.h>
+#include <cstddef>
+#include <cstdint>
 #include <string>
-#include <memory.h>
-
-#include "Global.hpp"
 
 #ifdef _WIN32
 #include <BaseTsd.h>
-typedef UINT_PTR SOCKET;
+using SOCKET = UINT_PTR;
 #endif
 
 struct sockaddr_in;

--- a/include/athena/Utility.hpp
+++ b/include/athena/Utility.hpp
@@ -1,11 +1,11 @@
 ﻿#ifndef __UTILITY_H__
 #define __UTILITY_H__
 
+#include <cstring>
 #include <string>
 #include <string_view>
 #include <vector>
-#include <cstdarg>
-#include <cstring>
+
 #include "athena/Global.hpp"
 #include "athena/Types.hpp"
 

--- a/include/athena/VectorWriter.hpp
+++ b/include/athena/VectorWriter.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <string>
-#include <memory>
-#include <functional>
+#include <cstdint>
 #include <vector>
+
 #include "athena/IStreamWriter.hpp"
+#include "athena/Types.hpp"
 
 namespace athena::io {
 

--- a/include/athena/YAMLCommon.hpp
+++ b/include/athena/YAMLCommon.hpp
@@ -4,13 +4,13 @@
 
 #pragma once
 
-#include <cstring>
-#include <yaml.h>
-#include <utf8proc.h>
-#include <vector>
 #include <memory>
-#include <functional>
-#include "Global.hpp"
+#include <string>
+#include <vector>
+
+#include <yaml.h>
+
+#include "athena/Types.hpp"
 
 namespace athena::io {
 class IStreamReader;

--- a/include/athena/YAMLDocReader.hpp
+++ b/include/athena/YAMLDocReader.hpp
@@ -1,6 +1,14 @@
 #pragma once
 
-#include "YAMLCommon.hpp"
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "athena/Types.hpp"
+#include "athena/YAMLCommon.hpp"
 
 namespace athena::io {
 

--- a/include/athena/YAMLDocWriter.hpp
+++ b/include/athena/YAMLDocWriter.hpp
@@ -1,6 +1,13 @@
 #pragma once
 
-#include "YAMLCommon.hpp"
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "athena/Types.hpp"
+#include "athena/YAMLCommon.hpp"
 
 namespace athena::io {
 

--- a/src/athena/Checksums.cpp
+++ b/src/athena/Checksums.cpp
@@ -1,7 +1,4 @@
 #include "athena/Checksums.hpp"
-#include "athena/FileReader.hpp"
-#include <iostream>
-#include <iomanip>
 
 namespace athena::checksums {
 atUint64 crc64(const atUint8* data, atUint64 length, atUint64 seed, atUint64 final) {

--- a/src/athena/Compression.cpp
+++ b/src/athena/Compression.cpp
@@ -1,8 +1,9 @@
 #include "athena/Compression.hpp"
+
 #if AT_LZOKAY
 #include <lzokay.hpp>
 #endif
-#include <iostream>
+
 #include <zlib.h>
 #include "LZ77/LZType10.hpp"
 #include "LZ77/LZType11.hpp"

--- a/src/athena/DNAYaml.cpp
+++ b/src/athena/DNAYaml.cpp
@@ -1,5 +1,10 @@
 #include "athena/DNAYaml.hpp"
 
+#include <cctype>
+#include <cstdlib>
+
+#include "athena/YAMLCommon.hpp"
+
 namespace athena::io {
 
 template <>

--- a/src/athena/Dir.cpp
+++ b/src/athena/Dir.cpp
@@ -1,10 +1,14 @@
 #include "athena/Dir.hpp"
-#include <sys/stat.h>
+
 #include <climits>
 #include <cstdlib>
 #include <ctime>
+#include <sys/stat.h>
+
 #define __STDC_FORMAT_MACROS
 #include <cinttypes>
+
+#include "athena/FileInfo.hpp"
 #include "athena/Utility.hpp"
 
 #ifndef _WIN32

--- a/src/athena/FileInfo.cpp
+++ b/src/athena/FileInfo.cpp
@@ -1,11 +1,13 @@
 #include "athena/FileInfo.hpp"
-#include "athena/Utility.hpp"
-#include "athena/FileWriter.hpp"
-#include "athena/FileReader.hpp"
-#include <ctime>
+
+#include <climits>
 #include <cstdio>
-#include <limits.h>
 #include <cstdlib>
+#include <ctime>
+
+#include "athena/FileReader.hpp"
+#include "athena/FileWriter.hpp"
+#include "athena/Utility.hpp"
 
 #ifndef _WIN32
 #include <sys/time.h>

--- a/src/athena/FileWriterGeneric.cpp
+++ b/src/athena/FileWriterGeneric.cpp
@@ -1,5 +1,7 @@
 #include "athena/FileWriter.hpp"
 
+#include <cstring>
+
 namespace athena::io {
 void TransactionalFileWriter::seek(atInt64 pos, SeekOrigin origin) {
   switch (origin) {

--- a/src/athena/MemoryReader.cpp
+++ b/src/athena/MemoryReader.cpp
@@ -1,11 +1,8 @@
 #include "athena/MemoryReader.hpp"
 
-#include <cstdio>
-#include <cstdlib>
-#include <vector>
-#include <iostream>
-#include <cstring>
 #include <algorithm>
+#include <cstdio>
+#include <cstring>
 
 #ifdef HW_RVL
 #include <malloc.h>

--- a/src/athena/MemoryWriter.cpp
+++ b/src/athena/MemoryWriter.cpp
@@ -2,8 +2,6 @@
 
 #include <cstdio>
 #include <cstring>
-#include <vector>
-#include <iostream>
 
 #ifdef HW_RVL
 #include <malloc.h>

--- a/src/athena/Socket.cpp
+++ b/src/athena/Socket.cpp
@@ -1,17 +1,20 @@
 #include "athena/Socket.hpp"
 
 #ifndef _WIN32
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <netinet/tcp.h>
+#include <cerrno>
+
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
 #include <unistd.h>
-#include <cerrno>
 #else
 #include <WinSock2.h>
 #include <Ws2tcpip.h>
 #endif
+
+#include "athena/Global.hpp"
 
 namespace athena::net {
 

--- a/src/athena/Utility.cpp
+++ b/src/athena/Utility.cpp
@@ -1,15 +1,16 @@
 ﻿#include "athena/Utility.hpp"
-#include <iostream>
-#include <cstring>
-#include <cstdlib>
-#include <sstream>
+
 #include <algorithm>
 #include <cstdarg>
-#include <iterator>
 #include <cstdio>
-#include <sys/types.h>
-#include <sys/stat.h>
+#include <cstdlib>
+#include <cstring>
+#include <iterator>
 #include <random>
+#include <sstream>
+
+#include <sys/stat.h>
+#include <sys/types.h>
 #include "utf8proc.h"
 
 #ifdef _MSC_VER

--- a/src/athena/VectorWriter.cpp
+++ b/src/athena/VectorWriter.cpp
@@ -1,10 +1,8 @@
 #include "athena/VectorWriter.hpp"
 
-#include <cstdio>
+#include <algorithm>
 #include <cstring>
 #include <vector>
-#include <iostream>
-#include <algorithm>
 
 namespace athena::io {
 


### PR DESCRIPTION
Removes unused headers and ensures that all necessary headers are included. In particular, this removes quite a few <iostream> includes, which removes quite a few static constructors.