### PR TITLE
MemoryWriter: Initialize member variables to deterministic values

### DIFF
--- a/include/athena/MemoryWriter.hpp
+++ b/include/athena/MemoryWriter.hpp
@@ -90,11 +90,11 @@ public:
   void writeUBytes(const atUint8* data, atUint64 length) override;
 
 protected:
-  MemoryWriter() {}
-  atUint8* m_data;
-  atUint64 m_length;
-  atUint64 m_position;
-  bool m_bufferOwned;
+  MemoryWriter() = default;
+  atUint8* m_data = nullptr;
+  atUint64 m_length = 0;
+  atUint64 m_position = 0;
+  bool m_bufferOwned = false;
   std::string m_filepath; //!< Path to the target file
 };
 


### PR DESCRIPTION
Makes the variable initialization behavior deterministic in the case of the default constructor. This also eliminates the possibility of an uninitialized read from occurring within the destructor entirely; even in the face of future changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/libathena/athena/57)
<!-- Reviewable:end -->
