### PR TITLE
MemoryWriter: Prevent potential leak within save()

### DIFF
--- a/src/athena/MemoryWriter.cpp
+++ b/src/athena/MemoryWriter.cpp
@@ -260,15 +260,14 @@ void MemoryCopyWriter::resize(atUint64 newSize) {
   }
 
   // Allocate and copy new buffer
-  atUint8* newArray = new atUint8[newSize];
-  memset(newArray, 0, newSize);
-
-  if (m_dataCopy)
-    memmove(newArray, m_dataCopy.get(), m_length);
-  m_dataCopy.reset(newArray);
+  auto newArray = std::make_unique<atUint8[]>(newSize);
+  if (m_dataCopy) {
+    std::memmove(newArray.get(), m_dataCopy.get(), m_length);
+  }
+  m_dataCopy = std::move(newArray);
 
   // Swap the pointer and size out for the new ones.
-  m_data = newArray;
+  m_data = m_dataCopy.get();
   m_length = newSize;
 }
 

--- a/src/athena/MemoryWriter.cpp
+++ b/src/athena/MemoryWriter.cpp
@@ -10,7 +10,7 @@
 namespace athena::io {
 
 MemoryWriter::MemoryWriter(atUint8* data, atUint64 length, bool takeOwnership)
-: m_data((atUint8*)data), m_length(length), m_position(0), m_bufferOwned(takeOwnership) {
+: m_data(data), m_length(length), m_bufferOwned(takeOwnership) {
   if (!data) {
     atError(fmt("data cannot be NULL"));
     setError();
@@ -156,7 +156,7 @@ void MemoryWriter::setData(atUint8* data, atUint64 length, bool takeOwnership) {
   if (m_bufferOwned)
     delete m_data;
 
-  m_data = (atUint8*)data;
+  m_data = data;
   m_length = length;
   m_position = 0;
   m_bufferOwned = takeOwnership;


### PR DESCRIPTION
Prevents potential leaks within failure cases in error cases (e.g. in the event of the non-throwing default exception handler).

While we're at it, we can also make some cleanups here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/libathena/athena/58)
<!-- Reviewable:end -->
