### PR TITLE
CMakeLists: Define -DNOMINMAX and -DWIN32_LEAN_AND_MEAN on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,11 @@ if(WIN32)
         src/athena/FileWriterWin32.cpp
         src/athena/FileReaderWin32.cpp
     )
+
+    target_compile_definitions(athena-core PRIVATE
+        -DNOMINMAX
+        -DWIN32_LEAN_AND_MEAN
+    )
 else()
     target_sources(athena-core PRIVATE
         src/athena/FileWriterNix.cpp

--- a/src/athena/FileWriterWin32.cpp
+++ b/src/athena/FileWriterWin32.cpp
@@ -3,9 +3,6 @@
 #include <algorithm>
 #include <limits>
 
-#undef min
-#undef max
-
 namespace athena::io {
 FileWriter::FileWriter(std::string_view filename, bool overwrite, bool globalErr)
 : m_fileHandle(0), m_globalErr(globalErr) {

--- a/src/athena/MemoryReader.cpp
+++ b/src/athena/MemoryReader.cpp
@@ -8,9 +8,6 @@
 #include <malloc.h>
 #endif // HW_RVL
 
-#undef min
-#undef max
-
 namespace athena::io {
 MemoryReader::MemoryReader(const void* data, atUint64 length, bool takeOwnership, bool globalErr)
 : m_data(data), m_length(length), m_position(0), m_owns(takeOwnership), m_globalErr(globalErr) {


### PR DESCRIPTION
Avoids needing to explicitly define these in code and also allow external targets to be unaffected by this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/libathena/athena/63)
<!-- Reviewable:end -->
