### PR TITLE
Global: Make operator|= and &= for enums constexpr

### DIFF
--- a/include/athena/Global.hpp
+++ b/include/athena/Global.hpp
@@ -95,12 +95,12 @@ typedef struct stat64 atStat64_t;
     using T = std::underlying_type_t<type>;                                                                            \
     return type(static_cast<T>(a) & static_cast<T>(b));                                                                \
   }                                                                                                                    \
-  inline type& operator|=(type& a, const type& b) {                                                                    \
+  constexpr type& operator|=(type& a, type b) {                                                                        \
     using T = std::underlying_type_t<type>;                                                                            \
     a = type(static_cast<T>(a) | static_cast<T>(b));                                                                   \
     return a;                                                                                                          \
   }                                                                                                                    \
-  inline type& operator&=(type& a, const type& b) {                                                                    \
+  constexpr type& operator&=(type& a, type b) {                                                                        \
     using T = std::underlying_type_t<type>;                                                                            \
     a = type(static_cast<T>(a) & static_cast<T>(b));                                                                   \
     return a;                                                                                                          \

--- a/include/athena/Global.hpp
+++ b/include/athena/Global.hpp
@@ -87,33 +87,33 @@ typedef struct stat64 atStat64_t;
 
 #ifndef ENABLE_BITWISE_ENUM
 #define ENABLE_BITWISE_ENUM(type)                                                                                      \
-  constexpr type operator|(type a, type b) {                                                                           \
+  constexpr type operator|(type a, type b) noexcept {                                                                  \
     using T = std::underlying_type_t<type>;                                                                            \
     return type(static_cast<T>(a) | static_cast<T>(b));                                                                \
   }                                                                                                                    \
-  constexpr type operator&(type a, type b) {                                                                           \
+  constexpr type operator&(type a, type b) noexcept {                                                                  \
     using T = std::underlying_type_t<type>;                                                                            \
     return type(static_cast<T>(a) & static_cast<T>(b));                                                                \
   }                                                                                                                    \
-  constexpr type& operator|=(type& a, type b) {                                                                        \
+  constexpr type& operator|=(type& a, type b) noexcept {                                                               \
     using T = std::underlying_type_t<type>;                                                                            \
     a = type(static_cast<T>(a) | static_cast<T>(b));                                                                   \
     return a;                                                                                                          \
   }                                                                                                                    \
-  constexpr type& operator&=(type& a, type b) {                                                                        \
+  constexpr type& operator&=(type& a, type b) noexcept {                                                               \
     using T = std::underlying_type_t<type>;                                                                            \
     a = type(static_cast<T>(a) & static_cast<T>(b));                                                                   \
     return a;                                                                                                          \
   }                                                                                                                    \
-  constexpr type operator~(type key) {                                                                                 \
+  constexpr type operator~(type key) noexcept {                                                                        \
     using T = std::underlying_type_t<type>;                                                                            \
     return type(~static_cast<T>(key));                                                                                 \
   }                                                                                                                    \
-  constexpr bool True(type key) {                                                                                      \
+  constexpr bool True(type key) noexcept {                                                                             \
     using T = std::underlying_type_t<type>;                                                                            \
     return static_cast<T>(key) != 0;                                                                                   \
   }                                                                                                                    \
-  constexpr bool False(type key) {                                                                                     \
+  constexpr bool False(type key) noexcept {                                                                            \
     using T = std::underlying_type_t<type>;                                                                            \
     return static_cast<T>(key) == 0;                                                                                   \
   }


### PR DESCRIPTION
While we're at it, we can also make them noexcept

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/libathena/athena/64)
<!-- Reviewable:end -->
