### PR TITLE
General: Be explicit about SeekOrigin and Endian types

### DIFF
--- a/atdna/test.hpp
+++ b/atdna/test.hpp
@@ -60,7 +60,7 @@ struct AT_SPECIALIZE_PARMS(atUint16, 42, atUint32, 87, atUint32, 2) TESTFile : p
   Value<atUint32> arrAltCount;
   Vector<atUint32, AT_DNA_COUNT(arrAltCount)> arrayAlt;
 
-  Seek<21, Current> seek;
+  Seek<21, SeekOrigin::Current> seek;
 
   Value<atUint32> arrCount2;
   Vector<TESTSubFile<ETest::ZERO>, AT_DNA_COUNT(arrCount[1] + arrCount2)> array2;

--- a/atdna/test.hpp
+++ b/atdna/test.hpp
@@ -1,7 +1,7 @@
 #include <athena/DNAYaml.hpp>
 
 using namespace athena;
-typedef io::DNA<Big> BigDNA;
+typedef io::DNA<Endian::Big> BigDNA;
 
 enum ETest : atUint8 { ZERO, ONE, TWO, THREE };
 
@@ -54,7 +54,7 @@ struct AT_SPECIALIZE_PARMS(atUint16, 42, atUint32, 87, atUint32, 2) TESTFile : p
   Value<TESTTemplateSubFile<atInt32, 36>> nestedTemplate1;
   Value<TESTTemplateSubFile<atInt64, 96>> nestedTemplate2;
 
-  Value<atUint32, Little> arrCount[2];
+  Value<atUint32, Endian::Little> arrCount[2];
   Vector<atUint32, AT_DNA_COUNT(arrCount[0])> array;
 
   Value<atUint32> arrAltCount;

--- a/include/athena/DNAOp.hpp
+++ b/include/athena/DNAOp.hpp
@@ -372,7 +372,7 @@ struct Read {
   }
   static void DoSeek(atInt64 amount, SeekOrigin whence, StreamT& r) { r.seek(amount, whence); }
   static void DoAlign(atInt64 amount, StreamT& r) {
-    r.seek((r.position() + amount - 1) / amount * amount, athena::Begin);
+    r.seek((r.position() + amount - 1) / amount * amount, athena::SeekOrigin::Begin);
   }
 };
 #define __READ_S(type, endian)                                                                                         \

--- a/include/athena/DNAYaml.hpp
+++ b/include/athena/DNAYaml.hpp
@@ -116,7 +116,7 @@ bool ValidateFromYAMLStream(athena::io::IStreamReader& fin) {
   atUint64 pos = fin.position();
   yaml_parser_set_input(reader.getParser(), (yaml_read_handler_t*)YAMLAthenaReader, &fin);
   bool retval = reader.ValidateClassType(DNASubtype::DNAType());
-  fin.seek(pos, athena::Begin);
+  fin.seek(pos, athena::SeekOrigin::Begin);
   return retval;
 }
 

--- a/include/athena/Utility.hpp
+++ b/include/athena/Utility.hpp
@@ -16,8 +16,8 @@ constexpr bool isSystemBigEndian() { return false; }
 #else
 constexpr bool isSystemBigEndian() { return __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__; }
 #endif
-constexpr ::athena::Endian SystemEndian = isSystemBigEndian() ? Big : Little;
-constexpr ::athena::Endian NotSystemEndian = isSystemBigEndian() ? Little : Big;
+constexpr ::athena::Endian SystemEndian = isSystemBigEndian() ? ::athena::Endian::Big : ::athena::Endian::Little;
+constexpr ::athena::Endian NotSystemEndian = isSystemBigEndian() ? ::athena::Endian::Little : ::athena::Endian::Big;
 
 #if _MSC_VER
 #define BSWAP_CONSTEXPR inline


### PR DESCRIPTION
Allows this code to still function if the enums are turned into enum classes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/libathena/athena/66)
<!-- Reviewable:end -->
