### PR TITLE
Global: Make SeekOrigin an enum class

### DIFF
--- a/include/athena/Global.hpp
+++ b/include/athena/Global.hpp
@@ -123,7 +123,7 @@ namespace athena {
 namespace error {
 enum class Level { Message, Warning, Error, Fatal };
 }
-enum SeekOrigin { Begin, Current, End };
+enum class SeekOrigin { Begin, Current, End };
 
 enum Endian { Little, Big };
 


### PR DESCRIPTION
Makes the enumeration strongly typed and also allows forward declaring the enumeration type as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/libathena/athena/67)
<!-- Reviewable:end -->
