### PR TITLE
General: Make Endian an enum class

### DIFF
--- a/include/athena/Global.hpp
+++ b/include/athena/Global.hpp
@@ -125,7 +125,7 @@ enum class Level { Message, Warning, Error, Fatal };
 }
 enum class SeekOrigin { Begin, Current, End };
 
-enum Endian { Little, Big };
+enum class Endian { Little, Big };
 
 namespace io {
 template <Endian DNAE>

--- a/include/athena/IStream.hpp
+++ b/include/athena/IStream.hpp
@@ -23,9 +23,9 @@ protected:
   void setError() { m_hasError = true; }
   bool m_hasError = false;
 #if __BYTE_ORDER == __BIG_ENDIAN
-  Endian m_endian = Big;
+  Endian m_endian = Endian::Big;
 #else
-  Endian m_endian = Little;
+  Endian m_endian = Endian::Little;
 #endif
 };
 } // namespace athena::io

--- a/include/athena/IStreamReader.hpp
+++ b/include/athena/IStreamReader.hpp
@@ -143,7 +143,7 @@ public:
   atInt16 readInt16() {
     atInt16 val = 0;
     readUBytesToBuf(&val, 2);
-    return m_endian == Big ? utility::BigInt16(val) : utility::LittleInt16(val);
+    return m_endian == Endian::Big ? utility::BigInt16(val) : utility::LittleInt16(val);
   }
   template <class T>
   atInt16 readVal(std::enable_if_t<std::is_same_v<T, atInt16>>* = nullptr) {
@@ -229,7 +229,7 @@ public:
   atInt32 readInt32() {
     atInt32 val = 0;
     readUBytesToBuf(&val, 4);
-    return m_endian == Big ? utility::BigInt32(val) : utility::LittleInt32(val);
+    return m_endian == Endian::Big ? utility::BigInt32(val) : utility::LittleInt32(val);
   }
   template <class T>
   atInt32 readVal(std::enable_if_t<std::is_same_v<T, atInt32>>* = nullptr) {
@@ -315,7 +315,7 @@ public:
   atInt64 readInt64() {
     atInt64 val = 0;
     readUBytesToBuf(&val, 8);
-    return m_endian == Big ? utility::BigInt64(val) : utility::LittleInt64(val);
+    return m_endian == Endian::Big ? utility::BigInt64(val) : utility::LittleInt64(val);
   }
   template <class T>
   atInt64 readVal(std::enable_if_t<std::is_same_v<T, atInt64>>* = nullptr) {
@@ -401,7 +401,7 @@ public:
   float readFloat() {
     float val = 0.f;
     readUBytesToBuf(&val, 4);
-    return m_endian == Big ? utility::BigFloat(val) : utility::LittleFloat(val);
+    return m_endian == Endian::Big ? utility::BigFloat(val) : utility::LittleFloat(val);
   }
   template <class T>
   float readVal(std::enable_if_t<std::is_same_v<T, float>>* = nullptr) {
@@ -446,7 +446,7 @@ public:
   double readDouble() {
     double val = 0.0;
     readUBytesToBuf(&val, 8);
-    return m_endian == Big ? utility::BigDouble(val) : utility::LittleDouble(val);
+    return m_endian == Endian::Big ? utility::BigDouble(val) : utility::LittleDouble(val);
   }
   template <class T>
   double readVal(std::enable_if_t<std::is_same_v<T, double>>* = nullptr) {
@@ -513,7 +513,7 @@ public:
   atVec2f readVec2f() {
     simd_floats val = {};
     readUBytesToBuf(val.data(), 8);
-    if (m_endian == Big) {
+    if (m_endian == Endian::Big) {
       val[0] = utility::BigFloat(val[0]);
       val[1] = utility::BigFloat(val[1]);
     } else {
@@ -581,7 +581,7 @@ public:
   atVec3f readVec3f() {
     simd_floats val = {};
     readUBytesToBuf(val.data(), 12);
-    if (m_endian == Big) {
+    if (m_endian == Endian::Big) {
       val[0] = utility::BigFloat(val[0]);
       val[1] = utility::BigFloat(val[1]);
       val[2] = utility::BigFloat(val[2]);
@@ -650,7 +650,7 @@ public:
   atVec4f readVec4f() {
     simd_floats val = {};
     readUBytesToBuf(val.data(), 16);
-    if (m_endian == Big) {
+    if (m_endian == Endian::Big) {
       val[0] = utility::BigFloat(val[0]);
       val[1] = utility::BigFloat(val[1]);
       val[2] = utility::BigFloat(val[2]);
@@ -720,7 +720,7 @@ public:
   atVec2d readVec2d() {
     simd_doubles val = {};
     readUBytesToBuf(val.data(), 16);
-    if (m_endian == Big) {
+    if (m_endian == Endian::Big) {
       val[0] = utility::BigDouble(val[0]);
       val[1] = utility::BigDouble(val[1]);
     } else {
@@ -788,7 +788,7 @@ public:
   atVec3d readVec3d() {
     simd_doubles val = {};
     readUBytesToBuf(val.data(), 24);
-    if (m_endian == Big) {
+    if (m_endian == Endian::Big) {
       val[0] = utility::BigDouble(val[0]);
       val[1] = utility::BigDouble(val[1]);
       val[2] = utility::BigDouble(val[2]);
@@ -857,7 +857,7 @@ public:
   atVec4d readVec4d() {
     simd_doubles val = {};
     readUBytesToBuf(val.data(), 32);
-    if (m_endian == Big) {
+    if (m_endian == Endian::Big) {
       val[0] = utility::BigDouble(val[0]);
       val[1] = utility::BigDouble(val[1]);
       val[2] = utility::BigDouble(val[2]);

--- a/include/athena/IStreamWriter.hpp
+++ b/include/athena/IStreamWriter.hpp
@@ -91,10 +91,11 @@ public:
    *  @param val The value to write to the buffer
    */
   void writeInt16(atInt16 val) {
-    if (m_endian == Big)
+    if (m_endian == Endian::Big) {
       utility::BigInt16(val);
-    else
+    } else {
       utility::LittleInt16(val);
+    }
     writeUBytes((atUint8*)&val, 2);
   }
   void writeVal(atInt16 val) { writeInt16(val); }
@@ -151,10 +152,11 @@ public:
    *  @param val The value to write to the buffer
    */
   void writeInt32(atInt32 val) {
-    if (m_endian == Big)
+    if (m_endian == Endian::Big) {
       utility::BigInt32(val);
-    else
+    } else {
       utility::LittleInt32(val);
+    }
     writeUBytes((atUint8*)&val, 4);
   }
   void writeVal(atInt32 val) { writeInt32(val); }
@@ -211,10 +213,11 @@ public:
    *  @param val The value to write to the buffer
    */
   void writeInt64(atInt64 val) {
-    if (m_endian == Big)
+    if (m_endian == Endian::Big) {
       utility::BigInt64(val);
-    else
+    } else {
       utility::LittleInt64(val);
+    }
     writeUBytes((atUint8*)&val, 8);
   }
   void writeVal(atInt64 val) { writeInt64(val); }
@@ -271,10 +274,11 @@ public:
    *  @param val The value to write to the buffer
    */
   void writeFloat(float val) {
-    if (m_endian == Big)
+    if (m_endian == Endian::Big) {
       val = utility::BigFloat(val);
-    else
+    } else {
       val = utility::LittleFloat(val);
+    }
     writeUBytes((atUint8*)&val, 4);
   }
   void writeVal(float val) { writeFloat(val); }
@@ -307,10 +311,11 @@ public:
    *  @param val The value to write to the buffer
    */
   void writeDouble(double val) {
-    if (m_endian == Big)
+    if (m_endian == Endian::Big) {
       utility::BigDouble(val);
-    else
+    } else {
       utility::LittleDouble(val);
+    }
     writeUBytes((atUint8*)&val, 8);
   }
   void writeVal(double val) { writeDouble(val); }
@@ -354,7 +359,7 @@ public:
    */
   void writeVec2f(const atVec2f& vec) {
     simd_floats tmp(vec.simd);
-    if (m_endian == Big) {
+    if (m_endian == Endian::Big) {
       tmp[0] = utility::BigFloat(tmp[0]);
       tmp[1] = utility::BigFloat(tmp[1]);
     } else {
@@ -398,7 +403,7 @@ public:
    */
   void writeVec3f(const atVec3f& vec) {
     simd_floats tmp(vec.simd);
-    if (m_endian == Big) {
+    if (m_endian == Endian::Big) {
       tmp[0] = utility::BigFloat(tmp[0]);
       tmp[1] = utility::BigFloat(tmp[1]);
       tmp[2] = utility::BigFloat(tmp[2]);
@@ -446,7 +451,7 @@ public:
    */
   void writeVec4f(const atVec4f& vec) {
     simd_floats tmp(vec.simd);
-    if (m_endian == Big) {
+    if (m_endian == Endian::Big) {
       tmp[0] = utility::BigFloat(tmp[0]);
       tmp[1] = utility::BigFloat(tmp[1]);
       tmp[2] = utility::BigFloat(tmp[2]);
@@ -498,7 +503,7 @@ public:
    */
   void writeVec2d(const atVec2d& vec) {
     simd_doubles tmp(vec.simd);
-    if (m_endian == Big) {
+    if (m_endian == Endian::Big) {
       tmp[0] = utility::BigDouble(tmp[0]);
       tmp[1] = utility::BigDouble(tmp[1]);
     } else {
@@ -542,7 +547,7 @@ public:
    */
   void writeVec3d(const atVec3d& vec) {
     simd_doubles tmp(vec.simd);
-    if (m_endian == Big) {
+    if (m_endian == Endian::Big) {
       tmp[0] = utility::BigDouble(tmp[0]);
       tmp[1] = utility::BigDouble(tmp[1]);
       tmp[2] = utility::BigDouble(tmp[2]);
@@ -590,7 +595,7 @@ public:
    */
   void writeVec4d(const atVec4d& vec) {
     simd_doubles tmp(vec.simd);
-    if (m_endian == Big) {
+    if (m_endian == Endian::Big) {
       tmp[0] = utility::BigDouble(tmp[0]);
       tmp[1] = utility::BigDouble(tmp[1]);
       tmp[2] = utility::BigDouble(tmp[2]);


### PR DESCRIPTION
Makes the type strongly-typed and not susceptible to implicit conversions. This also makes it more straightforward to migrate over to `std::endian` whenever that facility is available, given it's also an enum class. Given everything else has been migrated over to the qualified name of the enum values, this shouldn't break compilation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/libathena/athena/68)
<!-- Reviewable:end -->
