### PR TITLE
IStream: Remove unimplemented operator<< prototype

### DIFF
--- a/include/athena/IStream.hpp
+++ b/include/athena/IStream.hpp
@@ -3,7 +3,6 @@
 #include "athena/Global.hpp"
 
 namespace athena::io {
-std::ostream& operator<<(std::ostream& os, Endian& endian);
 
 class IStream {
 public:


### PR DESCRIPTION
The proper prototype and implementation lies within Global.cpp/.hpp, which takes a const reference rather than a non-const reference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/libathena/athena/70)
<!-- Reviewable:end -->
