### PR TITLE
Global: Remove compatibility formatting define for size_t 

### DIFF
--- a/atdna/test.cpp
+++ b/atdna/test.cpp
@@ -1,5 +1,7 @@
 #include "test.hpp"
-#include "athena/MemoryWriter.hpp"
+
+#include <athena/MemoryWriter.hpp>
+#include <fmt/format.h>
 
 #define EXPECTED_BYTES 281
 
@@ -13,11 +15,14 @@ int main(int argc, const char** argv) {
   athena::io::MemoryCopyWriter w(nullptr, binSize);
   atInt64 pos = w.position();
   file.write(w);
-  bool pass = !w.hasError() && w.position() - pos == binSize && binSize == EXPECTED_BYTES;
-  if (pass)
-    printf("[PASS] %" PRISize " bytes written\n", size_t(w.position() - pos));
-  else
-    printf("[FAIL] %" PRISize " bytes written; %" PRISize " bytes sized; %d bytes expected\n",
-           size_t(w.position() - pos), binSize, EXPECTED_BYTES);
+
+  const bool pass = !w.hasError() && w.position() - pos == binSize && binSize == EXPECTED_BYTES;
+  if (pass) {
+    fmt::print(fmt("[PASS] {} bytes written\n"), size_t(w.position() - pos));
+  } else {
+    fmt::print(fmt("[FAIL] {} bytes written; {} bytes sized; {} bytes expected\n"), size_t(w.position() - pos), binSize,
+               EXPECTED_BYTES);
+  }
+
   return pass ? 0 : 1;
 }

--- a/include/athena/Global.hpp
+++ b/include/athena/Global.hpp
@@ -30,14 +30,8 @@
 #if !defined(S_ISLNK)
 #define S_ISLNK(m) 0
 #endif
+#endif // _MSC_VER
 
-#define PRISize "Iu"
-
-#else
-
-#define PRISize "zu"
-
-#endif
 // clang-format off
 #ifndef AT_PRETTY_FUNCTION
 #   if defined(__PRETTY_FUNCTION__) || defined(__GNUC__)


### PR DESCRIPTION
Given the use of fmt, we can trivially remove the remaining usages of this define and remove it from the Global header. Even without fmt, MSVC has supported the use of `%zu` since C++11 support was added to the compiler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/libathena/athena/71)
<!-- Reviewable:end -->
