### PR TITLE
DNAYaml: Make use of if constexpr where applicable

### DIFF
--- a/include/athena/DNAYaml.hpp
+++ b/include/athena/DNAYaml.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <type_traits>
 
 #include "athena/DNA.hpp"
 #include "athena/FileReader.hpp"
@@ -12,13 +11,12 @@
 namespace athena::io {
 
 template <class T>
-inline std::string_view __GetDNAName(const T& dna, std::enable_if_t<athena::io::__IsDNAVRecord_v<T>>* = nullptr) {
-  return dna.DNATypeV();
-}
-
-template <class T>
-inline std::string_view __GetDNAName(const T& dna, std::enable_if_t<!athena::io::__IsDNAVRecord_v<T>>* = nullptr) {
-  return dna.DNAType();
+std::string_view __GetDNAName(const T& dna) {
+  if constexpr (__IsDNAVRecord_v<T>) {
+    return dna.DNATypeV();
+  } else {
+    return dna.DNAType();
+  }
 }
 
 template <class T>

--- a/src/athena/DNAYaml.cpp
+++ b/src/athena/DNAYaml.cpp
@@ -2,6 +2,7 @@
 
 #include <cctype>
 #include <cstdlib>
+#include <type_traits>
 
 #include "athena/YAMLCommon.hpp"
 

--- a/src/athena/DNAYaml.cpp
+++ b/src/athena/DNAYaml.cpp
@@ -139,20 +139,22 @@ std::unique_ptr<YAMLNode> ValToNode(double val) {
 
 template <typename RETURNTYPE>
 RETURNTYPE NodeToVec(const YAMLNode* node) {
-  constexpr bool isDouble = std::is_same<RETURNTYPE, atVec2d>::value || std::is_same<RETURNTYPE, atVec3d>::value ||
-                            std::is_same<RETURNTYPE, atVec4d>::value;
+  constexpr bool isDouble =
+      std::is_same_v<RETURNTYPE, atVec2d> || std::is_same_v<RETURNTYPE, atVec3d> || std::is_same_v<RETURNTYPE, atVec4d>;
   RETURNTYPE retval = {};
   auto it = node->m_seqChildren.begin();
   simd_values<std::conditional_t<isDouble, double, float>> f;
   for (size_t i = 0; i < 4 && it != node->m_seqChildren.end(); ++i, ++it) {
     YAMLNode* snode = it->get();
     if (snode->m_type == YAML_SCALAR_NODE) {
-      if (isDouble)
+      if constexpr (isDouble) {
         f[i] = NodeToVal<double>(snode);
-      else
+      } else {
         f[i] = NodeToVal<float>(snode);
-    } else
+      }
+    } else {
       f[i] = 0.0;
+    }
   }
   retval.simd.copy_from(f);
   return retval;


### PR DESCRIPTION
We can collapse two functions into a single function and also make use of it in `NodeToVec()`, where a constexpr boolean is tested against.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/libathena/athena/72)
<!-- Reviewable:end -->
